### PR TITLE
Add catalog-info.yaml file for release data

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,7 +7,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: staff-graded
+  name: staff-graded-xblock
 spec:
   type: 'library'
   owner: group:openedx-unmaintained

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,3 +10,4 @@ metadata:
   name: staff-graded
 spec:
   type: 'library'
+  owner: group:openedx-unmaintained

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,12 @@
+# This file records information about this repo. Its use is described in OEP-55:
+# https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0055-proc-project-maintainers.html
+#
+# If you're thinking about copying this, check out the sample file in the relevant ADR instead:
+# https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0055/decisions/0001-use-backstage-to-support-maintainers.html#references
+
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: staff-graded
+spec:
+  type: 'library'


### PR DESCRIPTION
Description:

Update catalog-info.yaml file for release data, as the BTR script has been updated https://github.com/openedx/repo-tools/issues/439 to read the catalog-info.yaml file if it has release data, we are updating the catalog-info file as per https://github.com/openedx/axim-engineering/issues/882