### PR TITLE
build: Normalize the name so that it's all dashes.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ VERSION = get_version("staff_graded/__init__.py")
 
 
 setup(
-    name='staff_graded-xblock',
+    name='staff-graded-xblock',
     version=VERSION,
     description='Staff Graded XBlock',   # TODO: write a better description.
     long_description='Staff Graded XBlock',  # TODO: write a better description.

--- a/staff_graded/__init__.py
+++ b/staff_graded/__init__.py
@@ -2,4 +2,4 @@
 
 from .staff_graded import StaffGradedXBlock
 
-__version__ = '3.0.0'
+__version__ = '3.0.1'


### PR DESCRIPTION
Having both dashes and underscores make this repo name strange and
doesn't match the [package name in PyPI](https://pypi.org/project/staff-graded-xblock/3.0.0/).  This change updates the package
name to match what's in PyPI.

Related: The repo name was also just updated to match the name with
dashes.
