### PR TITLE
Add django 5.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.11', '3.12']
-        toxenv: [quality, django42]
+        toxenv: [quality, django42, django52]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,18 @@
+==========
+Change Log
+==========
+..
+   All enhancements and patches to staff-graded-xblock will be documented
+   in this file.  It adheres to the structure of http://keepachangelog.com/ ,
+   but in reStructuredText instead of Markdown (for ease of incorporation into
+   Sphinx documentation and the PyPI description).
+   This project adheres to Semantic Versioning (http://semver.org/).
+   There should always be an "Unreleased" section for changes pending release.
+..
+Unreleased
+~~~~~~~~~~
+
+3.1.0 - 2025-04-28
+~~~~~~~~~~~~~~~~~~
+
+* Add Django 5.2 support

--- a/pylintrc
+++ b/pylintrc
@@ -381,6 +381,6 @@ ext-import-graph =
 int-import-graph = 
 
 [EXCEPTIONS]
-overgeneral-exceptions = Exception
+overgeneral-exceptions = builtins.Exception
 
 # 2e3a63b4656d2fe598f8145548bb1f0d6c829da7

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
         'Programming Language :: Python :: 3.12',
         'Framework :: Django',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
     ],
     packages=[
         'staff_graded',

--- a/staff_graded/__init__.py
+++ b/staff_graded/__init__.py
@@ -2,4 +2,4 @@
 
 from .staff_graded import StaffGradedXBlock
 
-__version__ = '3.0.1'
+__version__ = '3.1.0'

--- a/staff_graded/locale/settings.py
+++ b/staff_graded/locale/settings.py
@@ -25,7 +25,6 @@ TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
-USE_L10N = True
 
 USE_TZ = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = django{42}, quality
+envlist = django{42,52}, quality
 
 [testenv]
 allowlist_externals = 
     make
 deps = 
     django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<5.3
     -r{toxinidir}/requirements/ci.txt
 commands = 
     make test


### PR DESCRIPTION
- Resolved https://github.com/openedx/staff-graded-xblock/issues/302

### Add Django 5.2 Support

This PR updates the codebase to be compatible with Django 5.2 while maintaining compatibility with Django 4.2.

Changes Made:
- Update `ci` and `tox` files
- Ran `django-upgrade` to apply necessary syntax updates for Django 5.2.
- Run tests using `tox` command and resolved the warnings and outdated `pep8` usage
- Add `changelog`
- Ensured all modifications remain backward-compatible with Django 4.2.

#### django-upgrade usage:

I ran command `git ls-files -z -- '*.py' | xargs -0r django-upgrade --target-version 5.2`